### PR TITLE
Fix Save() failing on virtual texture asset

### DIFF
--- a/Source/Engine/Content/Assets/Texture.cpp
+++ b/Source/Engine/Content/Assets/Texture.cpp
@@ -36,7 +36,7 @@ bool Texture::Save(const StringView& path)
 
 bool Texture::Save(const StringView& path, const InitData* customData)
 {
-    if (OnCheckSave())
+    if (OnCheckSave(path))
         return true;
     ScopeLock lock(Locker);
 


### PR DESCRIPTION
Calling `Save("my-path")` on a virtual `Texture` failed because `my-path` was not passed to `OnCheckSave()` which in turn failed because it won't save assets with an empty path.